### PR TITLE
Drop Plone 4.0 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Currently 3 types are supported:
 Compatibility
 =============
 
-Runs with `Plone <http://www.plone.org/>`_ `4.0`, `4.1`, `4.2`, `4.3`.
+Runs with `Plone <http://www.plone.org/>`_ `4.1`, `4.2`, `4.3`.
 
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop Plone 4.0 support.
+  [jone]
 
 
 1.1 (2012-05-21)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(name='ftw.globalstatusmessage',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.0',
         'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',

--- a/test-plone-4.0.x.cfg
+++ b/test-plone-4.0.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.0.x.cfg
-    http://good-py.appspot.com/release/plone.app.z3cform/0.5-next
-
-package-name = ftw.globalstatusmessage


### PR DESCRIPTION
ftw.upgrade, which is a dependency of ftw.globalstatusmessage,
does not support Plone 4.0 anymore.

/cc @maethu 
/cc @ninfaj  this should fix the tests of your pull-request #2
