### PR TITLE
Chameleon support: fix status message class.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Chameleon support: fix status message class. [jone]
 
 
 1.4.1 (2015-05-06)

--- a/ftw/globalstatusmessage/browser/viewlets/statusmessage.pt
+++ b/ftw/globalstatusmessage/browser/viewlets/statusmessage.pt
@@ -2,7 +2,7 @@
     xmlns:metal="http://xml.zope.org/namespaces/metal"
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:define="settings view/settings;
-                type settings/type_choice;
+                type python:str(settings.type_choice);
                 title settings/title_textfield;
                 message settings/message_textfield">
     <dl class="" tal:attributes="class string: portalMessage ${type}">


### PR DESCRIPTION
When installing chameleon, the Message-Object in the class attribute is translated (e.g. `Fehler`), but it should always be the id (`error`) in order to have the correct CSS being applied.