### PR TITLE
Fix statusmessage DOM class.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix class assertion on DOM-Element.
+  [raphael-s]
 
 
 1.4.2 (2016-10-31)

--- a/ftw/globalstatusmessage/browser/viewlets/statusmessage.pt
+++ b/ftw/globalstatusmessage/browser/viewlets/statusmessage.pt
@@ -2,7 +2,7 @@
     xmlns:metal="http://xml.zope.org/namespaces/metal"
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:define="settings view/settings;
-                type python:str(settings.type_choice);
+                type python:str(settings.type_choice.__str__());
                 title settings/title_textfield;
                 message settings/message_textfield">
     <dl class="" tal:attributes="class string: portalMessage ${type}">

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -3,3 +3,6 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
 
 package-name = ftw.globalstatusmessage
+
+[versions]
+path.py = 8.2.1


### PR DESCRIPTION
Beacause of the previous fix for chameleon, there was a translated string added to the html element as a class. This is not useable for custom css styling.

We no use the `__str__` representation which reverts the changes made to the DOM.

//cc @jone 