### PR TITLE
Publish status message config to publisher receiver.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- New feature allows to send the global status message config to a
+ `ftw.publisher.receiver` instance. [mbaechtold, jone]
 
 
 1.5.0 (2017-02-17)

--- a/ftw/globalstatusmessage/browser/configure.zcml
+++ b/ftw/globalstatusmessage/browser/configure.zcml
@@ -9,6 +9,13 @@
         permission="ftw.globalstatusmessage.EditMessage"
         />
 
+    <browser:view
+        for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
+        name="global_statusmessage_config_receiver"
+        class=".publisher.ConfigReceiverView"
+        permission="ftw.globalstatusmessage.EditMessage"
+        />
+
     <browser:viewlet
         for="*"
         name="ftw.globalstatusmessage.statusmessageviewlet"

--- a/ftw/globalstatusmessage/browser/controlpanel.py
+++ b/ftw/globalstatusmessage/browser/controlpanel.py
@@ -1,7 +1,29 @@
 # -*- coding: utf-8 -*-
+from Acquisition._Acquisition import aq_inner
 from ftw.globalstatusmessage import _
 from ftw.globalstatusmessage.interfaces import IStatusMessageConfigForm
+from ftw.globalstatusmessage.utils import is_profile_installed
+from ftw.publisher.core.utils import decode_for_json
+from ftw.publisher.sender.utils import sendJsonToRealm
+from plone import api
 from plone.app.registry.browser import controlpanel
+from plone.registry.interfaces import IRegistry
+from Products.statusmessages import STATUSMESSAGEKEY
+from Products.statusmessages.interfaces import IStatusMessage
+from z3c.form import button
+from zope.annotation import IAnnotations
+from zope.component import getUtility
+from zope.i18nmessageid import MessageFactory
+from zope.schema import getFieldNames
+import json
+
+try:
+    from ftw.publisher.sender.interfaces import IConfig
+except ImportError:
+    FTW_PUBLISHER_SENDER_ON_PYTHON_PATH = False
+
+
+plone_messagefactory = MessageFactory("plone")
 
 
 class StatusMessageEditForm(controlpanel.RegistryEditForm):
@@ -10,5 +32,83 @@ class StatusMessageEditForm(controlpanel.RegistryEditForm):
     description = _(u'Settings for Global Status Message.')
 
 
+class PublishingStatusMessageEditForm(StatusMessageEditForm):
+    """
+    A special edit form which handles the publishing of the global status message
+    to a "ftw.publisher.receiver" instance.
+
+    Please note that the buttons are rendered in the order as they are defined.
+    """
+
+    @button.buttonAndHandler(plone_messagefactory(u"Save"), name='save')
+    def handleSave(self, action):
+        # Redeclare the save button because it is not inherited from the parent class.
+        super(PublishingStatusMessageEditForm, self).handleSave(self, action)
+
+    @button.buttonAndHandler(_(u'Save and publish'), name='save_and_publish')
+    def handleSaveAndPublish(self, action):
+        """
+        The additional button to send to a "ftw.publisher.receiver" instance.
+        """
+        self.handleSave(self, action)
+
+        self.send_to_receiver()
+
+        # Consume Plone messages set by `handleSave` so we can set our own message.
+        messages = IStatusMessage(self.request)
+        if messages.show():
+            self.request.response.cookies.pop(STATUSMESSAGEKEY)
+            IAnnotations(self.request)[STATUSMESSAGEKEY] = None
+
+        # Set a new Plone message.
+        api.portal.show_message(
+            message=_(u'Changes saved and published.'),
+            request=self.request,
+            type='info'
+        )
+
+    def updateActions(self):
+        super(PublishingStatusMessageEditForm, self).updateActions()
+        self.actions['save_and_publish'].addClass("context")
+
+    @button.buttonAndHandler(plone_messagefactory(u'Cancel'), name='cancel')
+    def handleCancel(self, action):
+        # Redeclare the cancel button because it is not inherited from the parent class.
+        super(PublishingStatusMessageEditForm, self).handleCancel(self, action)
+
+    def send_to_receiver(self):
+        data = json.dumps(
+            decode_for_json(self.get_settings_data())
+        )
+
+        realms = IConfig(api.portal.get()).getRealms()
+        for realm in realms:
+            sendJsonToRealm(
+                data,
+                realm,
+                'global_statusmessage_config_receiver'
+            )
+
+    def get_settings_data(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IStatusMessageConfigForm, check=False)
+
+        data = {
+            field_name: getattr(settings, field_name)
+            for field_name in getFieldNames(IStatusMessageConfigForm)
+        }
+
+        return data
+
+
 class StatusMessageControlPanel(controlpanel.ControlPanelFormWrapper):
     form = StatusMessageEditForm
+
+    def __init__(self, context, request):
+        super(StatusMessageControlPanel, self).__init__(context, request)
+
+        if is_profile_installed('profile-ftw.publisher.sender:default'):
+            self.form_instance = PublishingStatusMessageEditForm(
+                aq_inner(context), request
+            )
+            self.form_instance.__name__ = self.__name__

--- a/ftw/globalstatusmessage/browser/publisher.py
+++ b/ftw/globalstatusmessage/browser/publisher.py
@@ -1,0 +1,29 @@
+from ftw.globalstatusmessage.interfaces import IStatusMessageConfigForm
+from ftw.publisher.core import states
+from ftw.publisher.core.communication import createResponse
+from ftw.publisher.core.utils import encode_after_json
+from plone.registry.interfaces import IRegistry
+from Products.Five import BrowserView
+from zope.component import getUtility
+from zope.schema import getFieldNames
+import json
+
+
+class ConfigReceiverView(BrowserView):
+
+    def __call__(self):
+        data = encode_after_json(
+            json.loads(self.request.form.get('jsondata'))
+        )
+
+        if not data:
+            return createResponse(states.InvalidRequestError())
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IStatusMessageConfigForm, check=False)
+
+        for field_name in getFieldNames(IStatusMessageConfigForm):
+            if field_name in data:
+                setattr(settings, field_name, data[field_name])
+
+        return createResponse(states.SuccessState())

--- a/ftw/globalstatusmessage/configure.zcml
+++ b/ftw/globalstatusmessage/configure.zcml
@@ -10,7 +10,6 @@
     <include file="permissions.zcml" />
     <include zcml:condition="installed ftw.lawgiver" file="lawgiver.zcml" />
     <include package=".browser" />
-    <include package=".upgrades" />
 
     <five:registerPackage package="." initialize=".initialize" />
     <i18n:registerTranslations directory="locales" />
@@ -28,6 +27,7 @@
         description="Provides Global status message"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
+    <include package=".upgrades" />
 
     <genericsetup:registerProfile
         name="uninstall"

--- a/ftw/globalstatusmessage/locales/de/LC_MESSAGES/ftw.globalstatusmessage.po
+++ b/ftw/globalstatusmessage/locales/de/LC_MESSAGES/ftw.globalstatusmessage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-17 13:23+0000\n"
+"POT-Creation-Date: 2017-08-15 12:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,7 +11,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:9
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:65
+msgid "Changes saved and published."
+msgstr "Änderungen wurden gespeichert und veröffentlicht."
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:31
 msgid "Global Status Message"
 msgstr "Globale Statusnachricht"
 
@@ -23,16 +27,24 @@ msgstr "Globale Statusnachricht"
 msgid "Install browserlayer."
 msgstr ""
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "Provides Global status message"
 msgstr ""
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:10
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:48
+msgid "Save and publish"
+msgstr "Speichern und veröffentlichen"
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:32
 msgid "Settings for Global Status Message."
 msgstr "Einstellungen für Globale Statusnachricht"
 
 #: ./ftw/globalstatusmessage/configure.zcml:38
 msgid "Uninstall ftw.globalstatusmessage"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/upgrades/configure.zcml:73
+msgid "Update registry: enable new configuration enabled_anonymous"
 msgstr ""
 
 #: ./ftw/globalstatusmessage/upgrades/configure.zcml:64
@@ -43,7 +55,7 @@ msgstr ""
 msgid "error"
 msgstr "Fehler"
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "ftw.globalstatusmessage"
 msgstr ""
 
@@ -93,3 +105,4 @@ msgstr "Typ"
 #: ./ftw/globalstatusmessage/interfaces.py:23
 msgid "warning"
 msgstr "Warnung"
+

--- a/ftw/globalstatusmessage/locales/es/LC_MESSAGES/ftw.globalstatusmessage.po
+++ b/ftw/globalstatusmessage/locales/es/LC_MESSAGES/ftw.globalstatusmessage.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-17 13:23+0000\n"
+"POT-Creation-Date: 2017-08-15 12:54+0000\n"
 "PO-Revision-Date: 2014-06-02 11:18-0300\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,7 +12,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:9
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:65
+msgid "Changes saved and published."
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:31
 msgid "Global Status Message"
 msgstr "Mensaje de estado global"
 
@@ -24,16 +28,24 @@ msgstr "Mensaje de estado global"
 msgid "Install browserlayer."
 msgstr ""
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "Provides Global status message"
 msgstr ""
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:10
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:48
+msgid "Save and publish"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:32
 msgid "Settings for Global Status Message."
 msgstr "Configuración del mensaje de estado global"
 
 #: ./ftw/globalstatusmessage/configure.zcml:38
 msgid "Uninstall ftw.globalstatusmessage"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/upgrades/configure.zcml:73
+msgid "Update registry: enable new configuration enabled_anonymous"
 msgstr ""
 
 #: ./ftw/globalstatusmessage/upgrades/configure.zcml:64
@@ -44,7 +56,7 @@ msgstr ""
 msgid "error"
 msgstr "error"
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "ftw.globalstatusmessage"
 msgstr ""
 
@@ -94,3 +106,4 @@ msgstr "Tipo"
 #: ./ftw/globalstatusmessage/interfaces.py:23
 msgid "warning"
 msgstr "advertencia"
+

--- a/ftw/globalstatusmessage/locales/fi/LC_MESSAGES/ftw.globalstatusmessage.po
+++ b/ftw/globalstatusmessage/locales/fi/LC_MESSAGES/ftw.globalstatusmessage.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2017-02-17 13:23+0000\n"
+"POT-Creation-Date: 2017-08-15 12:54+0000\n"
 "PO-Revision-Date: 2017-02-17 14:36+0100\n"
 "Last-Translator: Petri Savolainen <petri.savolainen@iki.fi>\n"
 "Language-Team: \n"
@@ -16,7 +16,11 @@ msgstr ""
 "X-Generator: Poedit 1.7.5\n"
 "Language: fi\n"
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:9
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:65
+msgid "Changes saved and published."
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:31
 msgid "Global Status Message"
 msgstr "Sivustoilmoitin"
 
@@ -28,16 +32,24 @@ msgstr "Sivustoilmoitin"
 msgid "Install browserlayer."
 msgstr ""
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "Provides Global status message"
 msgstr ""
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:10
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:48
+msgid "Save and publish"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:32
 msgid "Settings for Global Status Message."
 msgstr "Sivustoilmoittimen asetukset"
 
 #: ./ftw/globalstatusmessage/configure.zcml:38
 msgid "Uninstall ftw.globalstatusmessage"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/upgrades/configure.zcml:73
+msgid "Update registry: enable new configuration enabled_anonymous"
 msgstr ""
 
 #: ./ftw/globalstatusmessage/upgrades/configure.zcml:64
@@ -48,7 +60,7 @@ msgstr ""
 msgid "error"
 msgstr "virhe"
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "ftw.globalstatusmessage"
 msgstr ""
 

--- a/ftw/globalstatusmessage/locales/ftw.globalstatusmessage.pot
+++ b/ftw/globalstatusmessage/locales/ftw.globalstatusmessage.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-17 13:23+0000\n"
+"POT-Creation-Date: 2017-08-15 12:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:9
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:65
+msgid "Changes saved and published."
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:31
 msgid "Global Status Message"
 msgstr ""
 
@@ -26,16 +30,24 @@ msgstr ""
 msgid "Install browserlayer."
 msgstr ""
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "Provides Global status message"
 msgstr ""
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:10
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:48
+msgid "Save and publish"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:32
 msgid "Settings for Global Status Message."
 msgstr ""
 
 #: ./ftw/globalstatusmessage/configure.zcml:38
 msgid "Uninstall ftw.globalstatusmessage"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/upgrades/configure.zcml:73
+msgid "Update registry: enable new configuration enabled_anonymous"
 msgstr ""
 
 #: ./ftw/globalstatusmessage/upgrades/configure.zcml:64
@@ -46,7 +58,7 @@ msgstr ""
 msgid "error"
 msgstr ""
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "ftw.globalstatusmessage"
 msgstr ""
 

--- a/ftw/globalstatusmessage/locales/pt_BR/LC_MESSAGES/ftw.globalstatusmessage.po
+++ b/ftw/globalstatusmessage/locales/pt_BR/LC_MESSAGES/ftw.globalstatusmessage.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-17 15:02+0000\n"
+"POT-Creation-Date: 2017-08-15 12:54+0000\n"
 "PO-Revision-Date: 2014-06-02 11:17-0300\n"
 "Last-Translator: Héctor Velarde <hector.velarde@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,7 +12,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:9
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:65
+msgid "Changes saved and published."
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:31
 msgid "Global Status Message"
 msgstr "Mensagem de estado global"
 
@@ -24,16 +28,24 @@ msgstr "Mensagem de estado global"
 msgid "Install browserlayer."
 msgstr ""
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "Provides Global status message"
 msgstr ""
 
-#: ./ftw/globalstatusmessage/browser/controlpanel.py:10
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:48
+msgid "Save and publish"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/browser/controlpanel.py:32
 msgid "Settings for Global Status Message."
 msgstr "Configuração da mensagem de estado global"
 
 #: ./ftw/globalstatusmessage/configure.zcml:38
 msgid "Uninstall ftw.globalstatusmessage"
+msgstr ""
+
+#: ./ftw/globalstatusmessage/upgrades/configure.zcml:73
+msgid "Update registry: enable new configuration enabled_anonymous"
 msgstr ""
 
 #: ./ftw/globalstatusmessage/upgrades/configure.zcml:64
@@ -44,7 +56,7 @@ msgstr ""
 msgid "error"
 msgstr "erro"
 
-#: ./ftw/globalstatusmessage/configure.zcml:30
+#: ./ftw/globalstatusmessage/configure.zcml:29
 msgid "ftw.globalstatusmessage"
 msgstr ""
 
@@ -94,3 +106,4 @@ msgstr "Tipo"
 #: ./ftw/globalstatusmessage/interfaces.py:23
 msgid "warning"
 msgstr "aviso"
+

--- a/ftw/globalstatusmessage/profiles/default/metadata.xml
+++ b/ftw/globalstatusmessage/profiles/default/metadata.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1500</version>
 </metadata>

--- a/ftw/globalstatusmessage/testing.py
+++ b/ftw/globalstatusmessage/testing.py
@@ -1,14 +1,14 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from plone.app.testing import applyProfile, PLONE_FIXTURE
 from plone.app.testing import FunctionalTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
+from plone.testing.z2 import installProduct
+from plone.testing.z2 import ZSERVER_FIXTURE
 from zope.configuration import xmlconfig
 import logging
 import sys
-
 
 handler = logging.StreamHandler(sys.stderr)
 logging.root.addHandler(handler)
@@ -16,13 +16,18 @@ logging.root.addHandler(handler)
 
 class ZCMLLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, ZSERVER_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        import ftw.globalstatusmessage
-        xmlconfig.file('configure.zcml',
-                       ftw.globalstatusmessage,
-                       context=configurationContext)
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
+            '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
+            '</configure>',
+            context=configurationContext)
+
+        installProduct(app, 'ftw.globalstatusmessage')
 
 STATUSMESSAGE_ZCML_LAYER = ZCMLLayer()
 STATUSMESSAGE_ZCML_FUNCTIONAL = FunctionalTesting(

--- a/ftw/globalstatusmessage/tests/__init__.py
+++ b/ftw/globalstatusmessage/tests/__init__.py
@@ -1,0 +1,16 @@
+from ftw.globalstatusmessage.testing import STATUSMESSAGE_FUNCTIONAL
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+import transaction
+
+
+class FunctionalTestCase(TestCase):
+    layer = STATUSMESSAGE_FUNCTIONAL
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()

--- a/ftw/globalstatusmessage/tests/helpers.py
+++ b/ftw/globalstatusmessage/tests/helpers.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+from zope.browser.interfaces import IBrowserView
+from zope.component import getGlobalSiteManager
+from zope.interface import Interface
+
+
+@contextmanager
+def view_registered(factory, name, required=(Interface, Interface)):
+    options = dict(
+        factory=factory,
+        required=required,
+        provided=IBrowserView,
+        name=name,
+    )
+    getGlobalSiteManager().registerAdapter(**options)
+    try:
+        yield
+    finally:
+        getGlobalSiteManager().unregisterAdapter(**options)

--- a/ftw/globalstatusmessage/upgrades/configure.zcml
+++ b/ftw/globalstatusmessage/upgrades/configure.zcml
@@ -64,17 +64,17 @@
         />
 
     <!-- 1400 -> 1500 -->
-    <genericsetup:upgradeSteps
+    <upgrade-step:importProfile
+        title="Update registry: enable new configuration enabled_anonymous"
+        profile="ftw.globalstatusmessage:default"
         source="1400"
         destination="1500"
-        profile="ftw.globalstatusmessage:default">
+        directory="profiles/1500"
+        />
 
-      <genericsetup:upgradeDepends
-          title="Update registry: enable new configuration enabled_anonymous"
-          import_steps="plone.app.registry"
-          run_deps="false"
-          />
-
-    </genericsetup:upgradeSteps>
+    <upgrade-step:directory
+        profile="ftw.globalstatusmessage:default"
+        directory="."
+        />
 
 </configure>

--- a/ftw/globalstatusmessage/upgrades/profiles/1500/registry.xml
+++ b/ftw/globalstatusmessage/upgrades/profiles/1500/registry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<registry>
+
+  <record interface="ftw.globalstatusmessage.interfaces.IStatusMessageConfigForm"
+          field="enabled_anonymous_bool">
+    <value>True</value>
+  </record>
+
+</registry>

--- a/ftw/globalstatusmessage/utils.py
+++ b/ftw/globalstatusmessage/utils.py
@@ -1,3 +1,5 @@
+import re
+from plone import api
 
 
 def is_path_included(path, included_paths, excluded_paths):
@@ -16,3 +18,36 @@ def is_path_included(path, included_paths, excluded_paths):
                       if path.startswith(site_path)]
     matching_sites.sort()
     return sites[matching_sites[-1]]
+
+
+def is_profile_installed(profileid):
+    """
+    Checks whether a generic setup profile is installed.
+    Respects product uninstallation via quickinstaller.
+
+    Inspired by `ftw.upgrade.step.UpgradeStep#is_profile_installed`.
+    """
+    profileid = re.sub(r'^profile-', '', profileid)
+    portal_setup = api.portal.get_tool('portal_setup')
+
+    try:
+        profileinfo = portal_setup.getProfileInfo(profileid)
+    except KeyError:
+        return False
+
+    if not is_product_installed(profileinfo['product']):
+        return False
+
+    version = portal_setup.getLastVersionForProfile(profileid)
+    return version != 'unknown'
+
+
+def is_product_installed(product_name):
+    """
+    Check whether a product is installed.
+
+    Inspired by `ftw.upgrade.step.UpgradeStep#is_product_installed`.
+    """
+    quickinstaller = api.portal.get_tool('portal_quickinstaller')
+    return quickinstaller.isProductInstallable(product_name) and \
+        quickinstaller.isProductInstalled(product_name)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
+    'ftw.publisher.sender',
     'plone.app.testing',
     'unittest2',
     'zope.configuration',


### PR DESCRIPTION
Usually our editors are not supposed to change things on the receiving end of `ftw.publisher`, but only on the sender.

With this new feature the config of the global status message can be transferred from the sender to the receiver instance.