### PR TITLE
Make the receiving endpoint available if "ftw.publisher.receiver" is installed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make the receiving endpoint available if `ftw.publisher.receiver`
+  is installed. Fixes 1.6.1. [mbaechtold]
 
 
 1.6.1 (2017-08-17)

--- a/ftw/globalstatusmessage/browser/configure.zcml
+++ b/ftw/globalstatusmessage/browser/configure.zcml
@@ -11,7 +11,7 @@
         />
 
     <browser:view
-        zcml:condition="installed ftw.publisher.sender"
+        zcml:condition="installed ftw.publisher.receiver"
         for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
         name="global_statusmessage_config_receiver"
         class=".publisher.ConfigReceiverView"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ tests_require = [
     'ftw.testbrowser',
     'ftw.testing',
     'ftw.publisher.sender',
+    'ftw.publisher.receiver',
     'plone.app.testing',
     'unittest2',
     'zope.configuration',


### PR DESCRIPTION
Follow-up of https://github.com/4teamwork/ftw.globalstatusmessage/pull/30