### PR TITLE
Plone5 conform html

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support both Plone 4 and 5 status message DOM. [Nachtalb]
 
 
 1.7.0 (2019-09-26)

--- a/ftw/globalstatusmessage/browser/viewlets/statusmessage.pt
+++ b/ftw/globalstatusmessage/browser/viewlets/statusmessage.pt
@@ -1,12 +1,26 @@
-<div id="globalstatusmessage" i18n:domain="ftw.globalstatusmessage"
+<html i18n:domain="ftw.globalstatusmessage"
     xmlns:metal="http://xml.zope.org/namespaces/metal"
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:define="settings view/settings;
                 type python:str(settings.type_choice.__str__());
                 title settings/title_textfield;
-                message settings/message_textfield">
-    <dl class="" tal:attributes="class string: portalMessage ${type}">
-        <dt tal:content="title">Attention</dt>
-        <dd tal:content="structure message">This is a sample Message</dd>
-    </dl>
-</div>
+                message settings/message_textfield;
+                class string: portalMessage ${type}">
+  <tal:plone_5 tal:condition="view/is_plone_5">
+    <aside id="globalstatusmessage">
+        <div class="" tal:attributes="class class">
+            <strong tal:content="title">Attention</strong>
+            <tal:message tal:content="structure message">This is a sample Message</tal:message>
+        </div>
+    </aside>
+  </tal:plone_5>
+
+  <tal:plone_4 tal:condition="not: view/is_plone_5">
+    <div id="globalstatusmessage">
+      <dl class="" tal:attributes="class class">
+          <dt tal:content="title">Attention</dt>
+          <dd tal:content="structure message">This is a sample Message</dd>
+      </dl>
+    </div>
+  </tal:plone_4>
+</html>

--- a/ftw/globalstatusmessage/browser/viewlets/statusmessage.py
+++ b/ftw/globalstatusmessage/browser/viewlets/statusmessage.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from ftw.globalstatusmessage.config import IS_PLONE_5
 from ftw.globalstatusmessage.interfaces import IStatusMessageConfigForm
 from ftw.globalstatusmessage.utils import is_path_included
 from plone import api
@@ -11,6 +12,7 @@ from zope.schema.interfaces import IVocabularyFactory
 
 class StatusmessageViewlet(common.PathBarViewlet):
     index = ViewPageTemplateFile('statusmessage.pt')
+    is_plone_5 = IS_PLONE_5
 
     def update(self):
         super(StatusmessageViewlet, self).update()

--- a/ftw/globalstatusmessage/config.py
+++ b/ftw/globalstatusmessage/config.py
@@ -1,2 +1,9 @@
 # -*- coding: utf-8 -*-
+from Products.CMFPlone.utils import getFSVersionTuple
+
 PROJECTNAME = 'ftw.globalstatusmessage'
+
+if getFSVersionTuple() > (5, ):
+    IS_PLONE_5 = True
+else:
+    IS_PLONE_5 = False


### PR DESCRIPTION
We add support for plone 4 & 5 DOM structure to be able to style both native plone status messages and ftw.globalstatusmessages at once. 

Pseudo code
```
if IS_PLONE_5:
    <div class="portalMessage information">
        <strong>Info</strong>
        Message
    </div>
else:
    <dl class="portalMessage information">
        <dt>Info</dt>
        <dd>Message</dd>
    </dl>
```