### PR TITLE
Handle unpublished sites in excluded sites.

### DIFF
--- a/ftw/globalstatusmessage/browser/controlpanel.py
+++ b/ftw/globalstatusmessage/browser/controlpanel.py
@@ -55,6 +55,14 @@ class PublishingStatusMessageEditForm(StatusMessageEditForm):
         """
         self.handleSave(self, action)
 
+        unpublished_elements = self.hans()
+        if unpublished_elements:
+            from Products.statusmessages.interfaces import IStatusMessage
+            msg.addStatusMessage(
+                'Wurde gespeichert aber nicht veroffentlicht weil nananan nicht veroffentlicht ist...',
+                type='error')
+            return
+
         self.send_to_receiver()
 
         # Consume Plone messages set by `handleSave` so we can set our own message.
@@ -102,6 +110,26 @@ class PublishingStatusMessageEditForm(StatusMessageEditForm):
         }
 
         return data
+
+    def hans(elisabeth):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IStatusMessageConfigForm, check=False)
+        fritz = settings.exclude_sites
+        cat = api.portal.get_tool('portal_catalog')
+        blabla = cat.unrestrictedSearchResults(
+            {'path': {'query': settings.exclude_sites, 'depth': 0}})
+
+        from Products.statusmessages.interfaces import IStatusMessage
+        from zope.component import getMultiAdapter
+        from ftw.publisher.sender.workflows.interfaces import IPublisherContextState
+        msg = IStatusMessage(elisabeth.request)
+        unpublished_elements = []
+        for bla in blabla:
+            if not getMultiAdapter((bla.getObject(), elisabeth.request),
+                                   IPublisherContextState).is_published():
+                unpublished_elements.append(bla)
+
+        return unpublished_elements
 
 
 class StatusMessageControlPanel(controlpanel.ControlPanelFormWrapper):

--- a/ftw/globalstatusmessage/testing.py
+++ b/ftw/globalstatusmessage/testing.py
@@ -1,9 +1,10 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
-from plone.app.testing import applyProfile, PLONE_FIXTURE
+from ftw.globalstatusmessage.tests import builders
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import applyProfile, PLONE_FIXTURE
 from plone.testing.z2 import installProduct
 from plone.testing.z2 import ZSERVER_FIXTURE
 from Products.CMFPlone.utils import getFSVersionTuple
@@ -29,6 +30,7 @@ class ZCMLLayer(PloneSandboxLayer):
             context=configurationContext)
 
         installProduct(app, 'ftw.globalstatusmessage')
+        installProduct(app, 'ftw.subsite')
 
 STATUSMESSAGE_ZCML_LAYER = ZCMLLayer()
 STATUSMESSAGE_ZCML_FUNCTIONAL = FunctionalTesting(
@@ -42,6 +44,7 @@ class InstallationLayer(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.globalstatusmessage:default')
+        applyProfile(portal, 'ftw.subsite:default')
 
         if getFSVersionTuple() > (5, ):
             applyProfile(portal, 'plone.app.contenttypes:default')

--- a/ftw/globalstatusmessage/tests/builders.py
+++ b/ftw/globalstatusmessage/tests/builders.py
@@ -1,0 +1,1 @@
+import ftw.subsite.tests.builders

--- a/ftw/globalstatusmessage/tests/test_controlpanel.py
+++ b/ftw/globalstatusmessage/tests/test_controlpanel.py
@@ -169,21 +169,23 @@ class PublishedControlPanelTestCase(FunctionalTestCase):
 
             # move options to the left and option_labels back to the right.
             option_labels = [u'unpublished']
-            to_list = browser.css('#form-widgets-exclude_sites-to')
             from_list = browser.css('#form-widgets-exclude_sites-from')
+            to_list = browser.css('#form-widgets-exclude_sites-to')
 
-            for option in from_list.css('option'):
-                to_list.append(option)
+            for option in to_list.css('option'):
+                if option:
+                    from_list.first.node.insert(1, option.node)
 
             for option_label in option_labels:
-                to_list.append(
-                    from_list.xpath(
-                        'option[text()="{}"]'.format(option_label)))
+                option_to_move = from_list.xpath(
+                    'option[text()="{}"]'.format(option_label)).first
+                if option_to_move:
+                    to_list.first.node.insert(1, option_to_move.node)
 
             browser.click_on('Save and publish')
 
         self.assertEqual(
-            ['Fritz'],
+            ['Some message that it was not published...'],
             error_messages()
         )
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'ftw.testing',
     'ftw.publisher.sender',
     'ftw.publisher.receiver',
+    'ftw.subsite',
     'plone.app.testing',
     'unittest2',
     'zope.configuration',


### PR DESCRIPTION
Close https://github.com/4teamwork/ogb/issues/217
Close https://extranet.4teamwork.ch/support/stadt-winterthur/tracker-web/158

I believe with 92b101e and a40dbde the problem is solved. It's quite a hassle to add a test since a widget is auto-added by Plone for the `List` field and there is not yet an implementation for `browser.fill` in `ftw.testbrowser` for that widget.