### PR TITLE
Filter not existing paths on receiver site.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Filter not existing paths on receiver site. [mathias.leimgruber]
 
 
 1.7.1 (2019-12-09)

--- a/ftw/globalstatusmessage/browser/publisher.py
+++ b/ftw/globalstatusmessage/browser/publisher.py
@@ -2,6 +2,7 @@ from ftw.globalstatusmessage.interfaces import IStatusMessageConfigForm
 from ftw.publisher.core import states
 from ftw.publisher.core.communication import createResponse
 from ftw.publisher.core.utils import encode_after_json
+from plone import api
 from plone.registry.interfaces import IRegistry
 from Products.Five import BrowserView
 from zope.component import getUtility
@@ -21,9 +22,17 @@ class ConfigReceiverView(BrowserView):
 
         registry = getUtility(IRegistry)
         settings = registry.forInterface(IStatusMessageConfigForm, check=False)
+        portal = api.portal.get()
 
         for field_name in getFieldNames(IStatusMessageConfigForm):
             if field_name in data:
-                setattr(settings, field_name, data[field_name])
+                if field_name == 'exclude_sites' and data[field_name]:
+                    existing_paths = filter(
+                        lambda path: portal.unrestrictedTraverse(path, None),
+                        data[field_name]
+                    )
+                    setattr(settings, field_name, existing_paths)
+                else:
+                    setattr(settings, field_name, data[field_name])
 
         return createResponse(states.SuccessState())


### PR DESCRIPTION
The vocabulary does not allow to the paths, which do not exists on the receiving plone site. 
But since, not all content is necessarily  published, we have to filter the list of subsites we receive. 

This PR replaces @busykoala https://github.com/4teamwork/ftw.globalstatusmessage/pull/36 which implements a round trip. But this is hard to test right now. 
So this PR specifically only tests the origin of the problem: "Setting the paths"